### PR TITLE
[diskinfo] wrapping most importants lowlevel functions.

### DIFF
--- a/cl-diskspace.asd
+++ b/cl-diskspace.asd
@@ -26,6 +26,7 @@
                       ((cffi-grovel:grovel-file "grovel-statvfs")
                        (:file "cl-diskspace-list-all-disks-with-df")
                        (:file "cl-diskspace-statvfs")
+                       #+linux
                        (:file "cl-diskspace-mount-ent")))
              #+win32
              (:module "win32"

--- a/cl-diskspace.asd
+++ b/cl-diskspace.asd
@@ -25,7 +25,8 @@
                       :components
                       ((cffi-grovel:grovel-file "grovel-statvfs")
                        (:file "cl-diskspace-list-all-disks-with-df")
-                       (:file "cl-diskspace-statvfs")))
+                       (:file "cl-diskspace-statvfs")
+                       (:file "cl-diskspace-mount-ent")))
              #+win32
              (:module "win32"
                       :serial t

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -12,8 +12,8 @@
            #:disk-free-space
            #:disk-available-space
            #:size-in-human-readable
-           #:mntent
-           #:set-mntent
-           #:get-mntent
-           #:end-mntent
-           #:lispify-plist-mntent))
+           #+linux #:mntent
+           #+linux #:set-mntent
+           #+linux #:get-mntent
+           #+linux #:end-mntent
+           #+linux #:lispify-plist-mntent))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -11,4 +11,9 @@
            #:disk-total-space
            #:disk-free-space
            #:disk-available-space
-           #:size-in-human-readable))
+           #:size-in-human-readable
+           #:mntent
+           #:set-mntent
+           #:get-mntent
+           #:end-mntent
+           #:lispify-plist-mntent))

--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -16,4 +16,7 @@
            #+linux #:set-mntent
            #+linux #:get-mntent
            #+linux #:end-mntent
-           #+linux #:lispify-plist-mntent))
+           #+linux #:lispify-plist-mntent
+           #+linux #:mountpoint->device
+           #+linux #:mountpoint->fstype
+           #+linux #:mountpoint->mnt-options))

--- a/src/unix/cl-diskspace-mount-ent.lisp
+++ b/src/unix/cl-diskspace-mount-ent.lisp
@@ -1,6 +1,6 @@
 (in-package #:cl-diskspace)
 
-(cffi:defcstruct mntent
+(defcstruct mntent
   (mnt_fsname :string)
   (mnt_dir    :string)
   (mnt_type   :string)
@@ -8,15 +8,15 @@
   (mnt_freq   :int)
   (mnt_passno :int))
 
-(cffi:defcfun (set-mntent "setmntent") :pointer (filename :string) (type :string))
+(defcfun (set-mntent "setmntent") :pointer (filename :string) (type :string))
 
-(cffi:defcfun (get-mntent "getmntent") :pointer (stream :pointer))
+(defcfun (get-mntent "getmntent") :pointer (stream :pointer))
 
-(cffi:defcfun (end-mntent "endmntent") :int (stream :pointer))
+(defcfun (end-mntent "endmntent") :int (stream :pointer))
 
 (defun lispify-plist-mntent (struct-as-plist)
   (mapcar (lambda (a)
             (if (symbolp a)
-                (cffi:translate-underscore-separated-name (symbol-name a))
+                (translate-underscore-separated-name (symbol-name a))
                 a))
           struct-as-plist))

--- a/src/unix/cl-diskspace-mount-ent.lisp
+++ b/src/unix/cl-diskspace-mount-ent.lisp
@@ -20,3 +20,45 @@
                 (translate-underscore-separated-name (symbol-name a))
                 a))
           struct-as-plist))
+
+(defun mntent-all-infos (&optional (mount-info-file "/etc/mtab"))
+  (let ((root-info (set-mntent mount-info-file "r"))
+        (infos     '()))
+    (if (not (cffi:null-pointer-p root-info))
+        (labels ((get-info ()
+                   (let ((info (get-mntent root-info)))
+                     (if (not (cffi:null-pointer-p info))
+                         (progn
+                           (push (cffi:convert-from-foreign info '(:struct mntent))
+                                 infos)
+                           (get-info))
+                         infos))))
+          (mapcar #'lispify-plist-mntent (get-info)))
+        (error (format nil "Can not open ~a" mount-info-file)))))
+
+(defun mntent-info (mtab plist-key looking-for-value)
+  (let ((all-infos (mntent-all-infos mtab)))
+    (find-if (lambda (a)
+               (let ((value-found (getf a plist-key nil)))
+                 (and value-found
+                      (string= value-found looking-for-value))))
+             all-infos)))
+
+(defun mountpoint-to->* (mount-info-file mountpoint key)
+  (let ((infos (mntent-info mount-info-file 'mnt-dir mountpoint)))
+    (and infos
+         (getf infos key nil))))
+
+(defun mountpoint->device (mountpoint &optional (mount-info-file "/etc/mtab"))
+  (mountpoint-to->* mount-info-file mountpoint 'mnt-fsname))
+
+(defun mountpoint->fstype (mountpoint &optional (mount-info-file "/etc/mtab"))
+  (mountpoint-to->* mount-info-file mountpoint 'mnt-type))
+
+(defun mountpoint->mnt-options (mountpoint &optional (mount-info-file "/etc/mtab"))
+  (let* ((raw            (mountpoint-to->* mount-info-file mountpoint 'mnt-opts))
+         (comma-splitted (cl-ppcre:split "," raw)))
+    (loop for i in comma-splitted collect
+         (if (cl-ppcre:scan "=" i)
+             (cl-ppcre:split "=" i)
+             i))))

--- a/src/unix/cl-diskspace-mount-ent.lisp
+++ b/src/unix/cl-diskspace-mount-ent.lisp
@@ -1,0 +1,22 @@
+(in-package #:cl-diskspace)
+
+(cffi:defcstruct mntent
+  (mnt_fsname :string)
+  (mnt_dir    :string)
+  (mnt_type   :string)
+  (mnt_opts   :string)
+  (mnt_freq   :int)
+  (mnt_passno :int))
+
+(cffi:defcfun (set-mntent "setmntent") :pointer (filename :string) (type :string))
+
+(cffi:defcfun (get-mntent "getmntent") :pointer (stream :pointer))
+
+(cffi:defcfun (end-mntent "endmntent") :int (stream :pointer))
+
+(defun lispify-plist-mntent (struct-as-plist)
+  (mapcar (lambda (a)
+            (if (symbolp a)
+                (cffi:translate-underscore-separated-name (symbol-name a))
+                a))
+          struct-as-plist))


### PR DESCRIPTION
Hi!

This is a partial wrapper to getmntent(3) and related functions, I think this could be useful for this library and to integrate your library with a stumpwm module (a module that check for disk related metrics).

Please consider merging.

Bye and thank you for your work!
C.

PS: to test that feature:

``` lisp
(in-package :cl-diskspace)

(defun test ()
  (let ((root-info (set-mntent "/etc/mtab" "r"))
        (infos     '()))
    (if (not (cffi:null-pointer-p root-info))
        (labels ((get-info ()
                   (let ((info (get-mntent root-info)))
                     (if (not (cffi:null-pointer-p info))
                         (progn
                           (push (cffi:convert-from-foreign info '(:struct mntent))
                                 infos)
                           (get-info))
                         infos))))
          (mapcar #'lispify-plist-mntent (get-info)))
        (error (format nil "Can not open /etc/mtab")))))
```


